### PR TITLE
[3주차] 거리합 구하기 - 박재환

### DIFF
--- a/FEB_WEEK3/거리합_구하기/박재환.java
+++ b/FEB_WEEK3/거리합_구하기/박재환.java
@@ -1,0 +1,126 @@
+import java.util.*;
+import java.io.*;
+
+// Softeer Lv.3
+// [21년 재직자 대회 본선] 거리 합 구하기
+// https://softeer.ai/practice/6258
+public class 박재환 {
+    static BufferedReader br;
+    static BufferedWriter bw;
+    static int node;
+    static ArrayList<int[]>[] tree;    // 각 노드의 연결을 기록 [연결 노드, 길이]
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        init();
+        // 입력 확인
+//        for(int idx=1; idx<node+1; idx++) {
+//            System.out.print(idx+" : ");
+//            for(int[] conn : tree[idx]) {
+//                System.out.print(conn[0]+" ");
+//            }
+//            System.out.println();
+//        }
+
+        박재환 problem = new 박재환();
+        StringBuilder sb = new StringBuilder();
+        long[] result = problem.allDistSum();
+        for(int n=1; n<node+1; n++) {
+            sb.append(result[n]).append('\n');
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+        bw.close();
+    }
+
+    private static void init() throws IOException {
+        node = Integer.parseInt(br.readLine().trim());
+        tree = new ArrayList[node+1];
+        for(int idx=1; idx<node+1; idx++) {
+            tree[idx] = new ArrayList<>();
+        }
+
+        // 간선 정보
+        for(int edge=0; edge<node-1; edge++) {
+            StringTokenizer st = new StringTokenizer(br.readLine().trim());
+            int nodeA = Integer.parseInt(st.nextToken());
+            int nodeB = Integer.parseInt(st.nextToken());
+            int dist = Integer.parseInt(st.nextToken());
+
+            tree[nodeA].add(new int[] {nodeB, dist});
+            tree[nodeB].add(new int[] {nodeA, dist});
+        }
+
+        br.close();
+    }
+
+    long[] subTree;
+    long[] distSum;
+    private long[] allDistSum() {
+        subTree = new long[node+1]; // 서브트리의 크기를 저장할 배열
+        distSum = new long[node+1]; // 서브트리의 크기를 저장할 배열
+        dfs(1,1);
+        dfs2(1,1);
+
+        // 서브트리 크기 확인
+//        for(long l : subTree) {
+//            System.out.println(l);
+//        }
+
+        // 거리합 확인
+//        for(long l : distSum) {
+//            System.out.println(l);
+//        }
+
+        return distSum;
+    }
+
+    /*
+    바텀업 방식으로
+    1. 서브트리의 크기를 구한다.
+    2. 각 노듸의 distSum 을 구한다 -> 📌 루트 노드를 기준으로!
+
+    바텀업 방식으로 서브트리의 크기와 루트 노드 기준 distSum 의 크기를 구한다.
+     */
+    private void dfs(int curNode, int parentNode) {
+        subTree[curNode] = 1;   // 자기 자신을 포함한 서브트리 크기 초기화
+
+        for(int[] nodeConn : tree[curNode]) {   // curNode 와 연결되어 있는 Node 들을 순회한다.
+            int childNode = nodeConn[0];
+            int dist = nodeConn[1];
+
+            if(childNode != parentNode) {   // 사이클 방지
+                dfs(childNode, curNode);  // 자신의 자식의 서브트리와, 루트노드로의 distSum 을 계산한다.
+                // 현재 노드까지의 거리합, 자식 노드까지의 거리합 -> 자식 서브트리 크기 * 자식 노드에서 현 노드까지 거리
+                distSum[curNode] += distSum[childNode] + subTree[childNode]*dist;
+                subTree[curNode] += subTree[childNode];
+            }
+        }
+    }
+
+
+    /*
+    루트노드 기준 거리합이 아닌, 다른 노드들이 루트일 때의 거리합을 구한다.
+
+    ⚠️ 탑 다운 방식을 사용한다.
+     */
+    private void dfs2(int curNode, int parentNode) {
+        for(int[] nodeConn : tree[curNode]) {   // curNode 와 연결되어 있는 Node 들을 순회한다.
+            int childNode = nodeConn[0];
+            int dist = nodeConn[1];
+
+            if(childNode != parentNode) {   // 사이클 방지
+                // 자식 노드 = 부모노드 + (N-subtree)*dist - subtree*dist
+                // => 부모노드 + (N-2*subtree) * dist
+                distSum[childNode] = distSum[curNode] + dist * (node-2*subTree[childNode]);
+                dfs2(childNode, curNode);  // 자신의 자식의 서브트리를 계산한다.
+            }
+        }
+    }
+}
+
+
+/*
+⭐ 서브트리와, 루트노드까지의 거리합을 기준으로 각 노드들의 거리합을 구할 수 있다.
+ */


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**:  [21년 재직자 대회 본선] 거리 합 구하기
- **문제 링크**: https://softeer.ai/practice/6258

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
- [ ] 
![image](https://github.com/user-attachments/assets/a0d100f1-df2f-47cb-9791-90161d116730)
![image](https://github.com/user-attachments/assets/da7c30f7-2989-45ca-806e-e94f8876f198)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
이번 문제는 트리의 특성을 이용할 수 있는 문제였습니다. 
문제의 풀이 방식은 루트노드를 기준으로 모든 거리의 합과, 각 노드들의 서브트리의 크기를 이용하여 상수시간 내에 모든 거리를 구할 수 있는 문제였습니다. 

총 2번의 DFS 가 필요합니다. 
첫 번째 DFS 는 바텀업 방식을 이용하여 각 노드의 서브트리의 크기와, 루트노드를 기준으로 하는 거리의 합을 구합니다.

두 번째 DFS 는 탑다운 방식을 이용하여 부모노드의 거리합으로부터 자식 노드의 거리합을 구합니다. 
자식 노드의 거리합 
= 부모 노드의 거리합 + (전체 노드 개수 - 서브 트리 노드 개수) * 부모노드와 자식 노드와의 거리 - (서브 트리 노드 개수) * 부모노드와 자식 노드와의 거리  
=> 부모 노드의 거리합 + 전체 노드 개수 - 2*서브 트리 노드 개수) * 부모노드와 자식 노드와의 거리 를 이용해 구할 수 있습니다.


## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
처음엔 플로이드워셜 알고리즘이 생각났고, 이는 O(N^3) 의 시간복잡도로 해결할 수 없는 방법이였습니다. 또한 탐색을 줄이기 위하여 트리구조이기 때문에 부모노드와의 연결만 고려하는 방법도 생각해보았는데 이 또한 시간초과였습니다. 

트리의 특성을 이용하고, 재귀호출을 통하여 문제를 해결할 수 있었습니다.

아래는 참고한 강의영상입니다. 
https://youtu.be/tvyDu2JBTpE?si=1XZYxmxQjsUOyWja