### PR TITLE
[4주차] 사물인식 최소 면적 산출 프로그램 - 정한슬

### DIFF
--- a/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/정한슬.java
+++ b/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/정한슬.java
@@ -1,0 +1,85 @@
+import java.io.*;
+import java.util.*;
+
+/*
+    N: 점의 개수 -> dotCount
+    K: 색깔의 개수 -> colorCount
+
+    1부터 20개까지의 색깔이 존재.
+    주어진 점들의 색깔들을 최소한 각각 1개씩은 포함하는 직사각형 중 넓이가 가장 작은 것을 출력
+    직사각형의 가로나 세로가 선분 혹은 점으로 나타나는 경우도 존재하며 이때는 넓이가 0이다.
+
+    플랫한 시야가 전혀 떠오르지 않아서.. 인터넷을 참고하여 dfs 접근이라는 것을 알게되어 풀이
+*/
+public class Main {
+  static BufferedReader br;
+  static BufferedWriter bw;
+  static StringTokenizer st;
+
+  static int dotCount;
+  static int colorCount;
+  static List<int[]>[] dotPositionByColor;
+  static int x;
+  static int y;
+  static int color;
+  static int minX = Integer.MAX_VALUE;
+  static int minY = Integer.MAX_VALUE;
+  static int maxX = Integer.MIN_VALUE;
+  static int maxY = Integer.MIN_VALUE;
+  static int minArea = Integer.MAX_VALUE;
+
+  public static void main(String[] args) throws IOException {
+    bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+    initInput();
+    for (int[] startPosition : dotPositionByColor[0]) {// 처음 색깔 먼저 넣어 dfs를 돌자
+      dfs(1, startPosition[0], startPosition[1], startPosition[0], startPosition[1]);
+    }
+
+    bw.write(String.valueOf(minArea));
+    bw.flush();
+    bw.close();
+  }
+
+  private static void dfs(int depth, int curMinX, int curMinY, int curMaxX, int curMaxY) {
+    if (depth == colorCount) { // 모든 색깔을 다 봤다면 끝.
+      int curArea = (curMaxX - curMinX) * (curMaxY - curMinY);
+      minArea = Math.min(minArea, curArea);
+      return;
+    }
+
+    for (int[] nextColorPosition : dotPositionByColor[depth]) { // 바로 다른 색깔 중에서도 minX, minY, maxX, maxY값을 찾아서 갱신하자.
+      // 그렇게 갱신하게 된다면, 이전 색깔 1개는 포함하는 과정이 될것
+      minX = Math.min(curMinX, nextColorPosition[0]);
+      minY = Math.min(curMinY, nextColorPosition[1]);
+      maxX = Math.max(curMaxX, nextColorPosition[0]);
+      maxY = Math.max(curMaxY, nextColorPosition[1]);
+
+      int tmpArea = (maxX - minX) * (maxY - minY);
+      if (minArea <= tmpArea) continue; // 만일 현재 색깔까지 갱신한 넓이가 최소값보다 같거나 크다면 이 면적은 포기하고 넘어간다.
+      dfs(depth + 1, minX, minY, maxX, maxY);
+    }
+
+  }
+
+  private static void initInput() throws IOException {
+    br = new BufferedReader(new InputStreamReader(System.in));
+    st = new StringTokenizer(br.readLine().trim());
+
+    dotCount = Integer.parseInt(st.nextToken());
+    colorCount = Integer.parseInt(st.nextToken());
+
+    dotPositionByColor = new ArrayList[colorCount];
+    for (int color = 0; color < colorCount; color++) {
+      dotPositionByColor[color] = new ArrayList<>();
+    }
+    for (int count = 0; count < dotCount; count++) {
+      st = new StringTokenizer(br.readLine().trim());
+      x = Integer.parseInt(st.nextToken());
+      y = Integer.parseInt(st.nextToken());
+      color = Integer.parseInt(st.nextToken());
+      dotPositionByColor[color - 1].add(new int[]{x, y});
+    }
+    br.close();
+  }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 사물인식 최소 면적 산출 프로그램 
- **문제 링크**: https://softeer.ai/practice/6277

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/407ac0f0-1960-4981-9be8-c7313025addd)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
점을 최소한 1개씩 포함하는 최소의 면적을 구하기 위해
색깔 별로 1개씩 다른 색깔과 판단하는 dfs 알고리즘을 선택했어야했습니다.
최악의 경우 소용없는 가지치기이지만, 현재까지 확인한 색깔들의 점을 갱신하여 넣은 넓이가 최소 넓이보다 같거나 크면 dfs에 들어가지 않도록 처리했습니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
플랫한 시야 너무 어렵네요..,, 