### PR TITLE
[4주차] 사물인식 최소 면적 산출 프로그램 - 박재환

### DIFF
--- a/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/박재환.java
+++ b/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/박재환.java
@@ -62,12 +62,6 @@ public class 박재환 {
     (현재 탐색중인 색상 idx, x의 최대, y의 최대, x의 최소, y의 최소)
      */
     private static void findMinArea(int colorIdx, int maxX, int maxY, int minX, int minY) {
-        // 현재 면적이 최소 면적보다 작으면 종료
-        // 더 이상 탐색할 가치가 없다
-        if(minArea < (maxX-minX) * (maxY-minY)) {
-            return;
-        }
-
         // 모든 색상을 탐색한 경우
         if(colorIdx == colorNums+1) {
             // 최소값을 갱신한다.
@@ -81,6 +75,12 @@ public class 박재환 {
             int nMaxY = Math.max(maxY, point[1]);
             int nMinX = Math.min(minX, point[0]);
             int nMinY = Math.min(minY, point[1]);
+
+            // 현재 면적이 최소 면적보다 작으면 종료
+            // 더 이상 탐색할 가치가 없다
+            if(minArea <= (nMaxX-nMinX) * (nMaxY-nMinY)) {
+                continue;
+            }
 
             // 다음 탐색을 진행한다.
             findMinArea(colorIdx+1, nMaxX, nMaxY, nMinX, nMinY);

--- a/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/박재환.java
+++ b/FEB_WEEK4/사물인식_최소_면적_산출_프로그램/박재환.java
@@ -1,0 +1,108 @@
+package 사물인식_최소_면적_산출_프로그램;
+
+import java.util.*;
+import java.io.*;
+
+// Softeer Lv.3
+// [HSAT 2회 정기 코딩 인증평가 기출] 사물인식 최소 면적 산출 프로그램
+// https://softeer.ai/practice/6277
+public class 박재환 {
+    static BufferedReader br;
+    static BufferedWriter bw;
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        // 입력
+        init();
+
+        
+    }
+
+    static int[][] map;  // 좌표를 2차원 배열로 표현
+    static List<int[]>[] colorDots;    // 각 색에 대한 점의 정보를 정보
+    static int dotNums, colorNums;  // 점의 개수, 색상의 종류
+    static int minArea; // 최소 면적
+    private static void init() throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine().trim());
+        dotNums = Integer.parseInt(st.nextToken());
+        colorNums = Integer.parseInt(st.nextToken());
+
+        map = new int[41][41];  // 여유롭게 좌표 설정 (-20,-20) -> (20,20)
+        // 1-base 배열 사용
+        colorDots = new ArrayList[colorNums+1];
+        for(int colorDot=0; colorDot<=colorNums; colorDot++) {
+            colorDots[colorDot] = new ArrayList<>();
+        }
+
+        for(int color=0; color<dotNums; color++) {
+            st = new StringTokenizer(br.readLine().trim());
+
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            int colorNo = Integer.parseInt(st.nextToken());
+
+            map[y+20][x+20] = colorNo;
+            // 각 색상의 점 정보를 저장한다.
+            colorDots[colorNo].add(new int[] {x,y});
+        }
+
+        minArea = Integer.MAX_VALUE;
+
+        findMinArea(1,-1000,-1000,1000,1000);
+
+        bw.write(String.valueOf(minArea));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    /*
+    최소 면적을 찾는다
+    (현재 탐색중인 색상 idx, x의 최대, y의 최대, x의 최소, y의 최소)
+     */
+    private static void findMinArea(int colorIdx, int maxX, int maxY, int minX, int minY) {
+        // 현재 면적이 최소 면적보다 작으면 종료
+        // 더 이상 탐색할 가치가 없다
+        if(minArea < (maxX-minX) * (maxY-minY)) {
+            return;
+        }
+
+        // 모든 색상을 탐색한 경우
+        if(colorIdx == colorNums+1) {
+            // 최소값을 갱신한다.
+            minArea = Math.min(minArea, (maxX-minX) * (maxY-minY));
+            return;
+        }
+
+        // 더 탐색할 색상이 남아있다면
+        for(int[] point : colorDots[colorIdx]) {
+            int nMaxX = Math.max(maxX, point[0]);
+            int nMaxY = Math.max(maxY, point[1]);
+            int nMinX = Math.min(minX, point[0]);
+            int nMinY = Math.min(minY, point[1]);
+
+            // 다음 탐색을 진행한다.
+            findMinArea(colorIdx+1, nMaxX, nMaxY, nMinX, nMinY);
+        }
+    }
+}
+
+/*
+    인식된 정도는 평면에 N 개의 점으로 주어진다
+    각 점들을 K 개의 색 중 하나를 가진다.
+
+    주어진 K 개의 색에 대해 {1,2,3,...,K}
+    해당 색깔을 가지는 점들을 적어도 하나씩 포함하는 사물 중
+    넓이가 가장 작은 것을 찾아 반환한다. ( 직사각형 )
+
+    내부와 경계 모두 직사각형으로 포함
+    가로와 세로가 0이되어 선분 혹은 점으로 나타나는 경우도 직사각형으로 인정 -> 넓이 0
+
+    제약조건
+    1 ≤ N ≤ 10
+    1 ≤ K ≤ 20
+    -1,000 ≤ x, y ≤ 1,000
+    -1,000 ≤ x, y ≤ 1,000 -> [2000][2000]????
+    1 ≤ k ≤ K
+  */


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 사물인식 최소 면적 산출 프로그램
- **문제 링크**: https://softeer.ai/practice/6277

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/88d28919-8628-4920-8ded-8109cfbf8f60)

![image](https://github.com/user-attachments/assets/fce9a983-d944-4a33-963f-00af6d8a21f0)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
직사각형의 넓이를 구하기 위해서는 최대값 (x,y) 와 최소값 (x,y) 를 구하여 두 값의 차를 통해 넓이를 구하였습니다.
따라서 각 색상의 점 위치를 각각 기록해 놓는 배열을 생성하여 각 색상의 모든 점들의 조합을 통해 문제를 해결하였습니다.

또한 이렇게 접근할 경우 5^20 의 시간복잡도를 가지게 되는데, 이를 고려하여 이전에 구한 최소 면적보다 크기가 커지는 경우 가지치기를 통해 탐색 수를 감소시켰습니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
가지 치기를 생각하지 못한 것은 아닌데, 조건문의 위치에 따라 탐색 시간이 달라질 수 있음을 몸소 느꼈습니다. 
최소 면적보다 현재 현적이 큰 경우 를 함수 호출 이후 실행하는 경우 스택에 쌓고 이를 빼내는 과정에서 시간초과가 나게 되었고, 애초에 해당 조건을 기준으로 하여 스택에 쌓고 이를 호출하는 과정을 제거하여 시간초과 늪에서 나올 수 있었습니다...
