### PR TITLE
[2주차] 석유 시추 - 정한슬

### DIFF
--- a/MAR/WEEK2/석유_시추/정한슬.java
+++ b/MAR/WEEK2/석유_시추/정한슬.java
@@ -1,0 +1,98 @@
+import java.util.*;
+
+/*
+    1. 1인 곳마다 bfs로 탐색하여 연결되어 있는 영역의 크기를 구한다.
+    2. 영역의 크기를 구할때마다 새로운 col이면 set에 기록을 해둔다.
+    3. Map을 만들어 col별로 영역의 크기를 저장한다.
+    4. 1과 2에서 찾은 영역을 col별로 더해서 저장한다.
+    ex> col 1, 2, 3에 걸친 영역 8을 map.get(1) + 8, map.get(2) + 8, .. 으로 갱신한다.
+*/
+class 정한슬 {
+  static int[] DR = {1, 0 , -1, 0};
+  static int[] DC = {0, 1, 0, -1};
+
+  static Map<Integer, Integer> areasByCols; // col별로 영역의 크기를 저장하는 맵
+  static int rowLength, colLength;
+  static int curRow, curCol, nextRow, nextCol, curArea, curMaxArea;
+  static boolean[][] isVisited;
+  static int[][] land;
+
+  public int solution(int[][] land) {
+    rowLength = land.length;
+    colLength = land[0].length;
+    this.land = land;
+    initMap();
+    isVisited = new boolean[rowLength][colLength];
+
+    for (int row = 0; row < rowLength; row++) {
+      for (int col = 0; col < colLength; col++) {
+        if (isVisited[row][col]) continue; // 이미 확인한 영역 중 하나면 pass
+
+        if (land[row][col] == 1) {
+          findArea(row, col);
+        }
+      }
+    }
+    return findMaxArea();
+  }
+
+  private static int findMaxArea() {
+    int maxResult = 0;
+    for (Map.Entry<Integer, Integer> areaEntry : areasByCols.entrySet()) {
+      maxResult = Math.max(maxResult, areaEntry.getValue());
+    }
+    return maxResult;
+  }
+
+  private static void findArea(int row, int col) {
+    Queue<int[]> queue = new ArrayDeque<>();
+    queue.add(new int[]{row, col}); // 1로 해서 curArea로 같이 담으면 틀림 ,, .. 왜?
+    isVisited[row][col] = true;
+    Set<Integer> colsSet = new HashSet<>();
+    colsSet.add(col);
+    curMaxArea = 0;
+
+    curArea = 0;
+    while (!queue.isEmpty()) {
+      int[] curStatus = queue.poll();
+      curRow = curStatus[0];
+      curCol = curStatus[1];
+
+      curArea++;
+
+      curMaxArea = Math.max(curMaxArea, curArea);
+
+      for (int direction = 0; direction < 4; direction++) {
+        nextRow = curRow + DR[direction];
+        nextCol = curCol + DC[direction];
+
+        if (!isInBoard(nextRow, nextCol)) continue;
+
+        if (land[nextRow][nextCol] == 0) continue;
+
+        if (isVisited[nextRow][nextCol]) continue;
+
+        queue.add(new int[]{nextRow, nextCol, curArea + 1});
+        isVisited[nextRow][nextCol] = true;
+        if (!colsSet.contains(nextCol)) colsSet.add(nextCol);
+      }
+    }
+
+    // 다 끝났으면 맵에 col별로 영역 추가로 저장
+    for (Integer uniqueCol : colsSet) {
+      int newArea = areasByCols.get(uniqueCol) + curMaxArea;
+      areasByCols.put(uniqueCol, newArea);
+    }
+  }
+
+  private static void initMap() {
+    areasByCols = new HashMap<>();
+    for (int col = 0; col < colLength; col++) {
+      areasByCols.put(col, 0);
+    }
+  }
+
+  private static boolean isInBoard(int row, int col) {
+    return row >= 0 && row < rowLength && col >= 0 && col < colLength;
+  }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 석유 시추
- **문제 링크**: https://school.programmers.co.kr/learn/courses/30/lessons/250136

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/e88fdf7b-706b-4097-a636-9722829d7ce0)


## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
bfs로 풀었습니다.

1. 1인 곳마다 bfs로 탐색하여 연결되어 있는 영역의 크기를 구한다.
2. 영역의 크기를 구할때마다 새로운 col이면 set에 기록을 해둔다.
3. Map을 만들어 col별로 영역의 크기를 저장한다.
4. 1과 2에서 찾은 영역을 col별로 더해서 저장한다.
    ex> col 1, 2, 3에 걸친 영역 8을 map.get(1) + 8, map.get(2) + 8, .. 으로 갱신한다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
처음에 curArea를 int[] 배열에 넣은 뒤에 다음 칸으로 옮길때 curArea + 1로 queue 넣는 거로 구현했는데 틀렸어용