### PR TITLE
[2주차] 서버 증설 횟수 - 이수빈

### DIFF
--- a/MAR/WEEK2/서버_증설_횟수/이수빈.java
+++ b/MAR/WEEK2/서버_증설_횟수/이수빈.java
@@ -1,0 +1,27 @@
+class Solution {
+    int[] serverCnt;
+    int serverMaxUserCnt, serverMaxTime;
+    
+    public int solution(int[] players, int m, int k) {
+        int answer = 0;
+        serverMaxUserCnt = m;
+        serverMaxTime = k;
+        serverCnt = new int[24];
+        
+        for (int time = 0; time < 24; time++) {
+            int needTotalServerCnt = players[time] / serverMaxUserCnt;
+            
+            if (serverCnt[time] < needTotalServerCnt) {
+                int addServerCnt = needTotalServerCnt - serverCnt[time];
+                
+                for (int serverTime = time; serverTime < time + serverMaxTime; serverTime++) {
+                    if (serverTime >= 24) break;
+                    serverCnt[serverTime] += addServerCnt;
+                }
+                answer += addServerCnt;
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 서버 증설 횟수
- **문제 링크**: https://school.programmers.co.kr/learn/courses/30/lessons/389479

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
![image](https://github.com/user-attachments/assets/f69ba63b-c4ef-460c-b9ee-a4b36979b4a4)

- [ ] 풀이 진행 중 

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
1. 시간별로 가동되는 서버의 개수를 관리하는 배열(serverCnt)을 생성한다.
2. 시간마다 반복문 돌며 해당 시간에 필요한 서버 개수를 구해준다.
3. 2번에서 구한 서버 개수가 serverCnt[time]보다 작다면, 증설할 서버 개수(serverCnt[time] - 2번의 개수)를 구해주고 serverCnt배열에 서버 최대 시간만큼 더해준다.
4. 증설할 서버 개수를 answer에 더해준다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
