### PR TITLE
[2주차] 석유시추 - 정연수

### DIFF
--- a/MAR/WEEK2/석유_시추/정연수.java
+++ b/MAR/WEEK2/석유_시추/정연수.java
@@ -1,0 +1,54 @@
+import java.io.*;
+import java.util.*;
+
+class Solution {
+    int[] totalOil;
+    int[][] oilLand;
+    int[][] visit;
+    int[] dy = {-1, 1, 0, 0};
+    int[] dx = {0, 0, -1, 1};
+    
+    void bfs(int row, int col) {
+        int count = 1;
+        ArrayDeque<int[]> q = new ArrayDeque<>();
+        Set<Integer> s = new HashSet<>();
+        q.add(new int[]{row, col});
+        s.add(col);
+        visit[row][col] = 1;
+        while(!q.isEmpty()) {
+            int[] cur = q.poll();
+            for (int i = 0; i < 4; i++) {
+                int nxtRow = cur[0] + dy[i];
+                int nxtCol = cur[1] + dx[i];
+                if (nxtRow < 0 || visit.length <= nxtRow || nxtCol < 0 || visit[0].length <= nxtCol) continue;
+                if (visit[nxtRow][nxtCol] == 1 || oilLand[nxtRow][nxtCol] == 0) continue;
+                visit[nxtRow][nxtCol] = 1;
+                count++;
+                s.add(nxtCol);
+                q.add(new int[]{nxtRow, nxtCol});
+            }
+        }
+        for (int idx : s) {
+            totalOil[idx] += count;
+        }
+    }
+    
+    public int solution(int[][] land) {
+        int answer = 0;
+        totalOil = new int[land[0].length];
+        visit = new int[land.length][land[0].length];
+        oilLand = land;
+        
+        for (int row = 0; row < land.length; row++) {
+            for (int col = 0; col < land[0].length; col++) {
+                if (land[row][col] == 0 || visit[row][col] == 1) continue;
+                bfs(row, col);
+            }
+        }
+        
+        for (int idx = 0; idx < totalOil.length; idx++) {
+            answer = Math.max(answer, totalOil[idx]);
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 석유시추
- **문제 링크**: https://school.programmers.co.kr/learn/courses/30/lessons/250136

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
flood fill 입니다. 너비 탐색으로 전체 석유의 넓이를 구한 후 해당을 시추 할 수 있는 곳에 더해줍니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
