### PR TITLE
[2주차] 서버 증설 횟수 - 정한슬

### DIFF
--- a/MAR/WEEK2/서버_증설_횟수/정한슬.java
+++ b/MAR/WEEK2/서버_증설_횟수/정한슬.java
@@ -1,0 +1,42 @@
+import java.util.*;
+
+
+/*
+    1. 0시부터 23시까지 증설된 서버의 수를 저장할 int[] 배열을 만든다.
+    2. players 배열을 돌면서, 게임 이용자 수가 m 이상 일때  players[i] /m 몫 만큼의 서버가 증설된다.
+        -> 증설된 서버의 수를 저장
+    3. 증설된 서버는 연속된 뒤의 k - 1 index까지 유지가 된다.
+*/
+class 정한슬 {
+  static int addServerCount;
+  static int curAddServerCount;
+  static int[] hours;
+
+  public int solution(int[] players, int m, int k) {
+    addServerCount = 0;
+    hours = new int[24];
+
+    for (int idx = 0; idx < players.length; idx++) {
+      if (players[idx] < m) continue;
+
+      int q = players[idx] / m;
+      if (hours[idx] >= q) continue;
+
+      if (hours[idx] != 0) {
+        curAddServerCount =  q - hours[idx];
+      } else {
+        curAddServerCount =  q;
+      }
+
+      if (q > 0) {
+        for (int count = 0; count < k; count++) {
+          if (idx + count >= 24) break;
+          hours[idx + count] += curAddServerCount;
+        }
+      }
+      addServerCount += curAddServerCount;
+    }
+
+    return addServerCount;
+  }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 서버 증설 횟수
- **문제 링크**: https://school.programmers.co.kr/learn/courses/30/lessons/389479

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/2ebfa8bf-bf62-4cc3-9c88-40f0f1355f4f)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
    1. 0시부터 23시까지 증설된 서버의 수를 저장할 int[] 배열을 만든다.
    2. players 배열을 돌면서, 게임 이용자 수가 m 이상 일때  players[i] /m 몫 만큼의 서버가 증설된다.
        -> 증설된 서버의 수를 저장
    3. 증설된 서버는 연속된 뒤의 k - 1 index까지 유지가 된다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
