### PR TITLE
[2주차] 정연수 - 캐시

### DIFF
--- a/MAR/WEEK2/캐시/정연수.java
+++ b/MAR/WEEK2/캐시/정연수.java
@@ -1,0 +1,40 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int cacheSize, String[] cities) {
+        int answer = 0;
+        HashMap<String, Integer> cache = new HashMap<>();  // 캐시 (도시 이름을 키로 사용)
+        LinkedList<String> lruList = new LinkedList<>();   // LRU 순서 관리
+        
+        for (String city : cities) {
+            String cityLower = city.toLowerCase();  // 대소문자 구분 없이 처리
+            
+            // cache hit 확인
+            if (cache.containsKey(cityLower)) {
+                answer += 1;  // cache hit
+                
+                // LRU 순서 업데이트 (기존 위치에서 제거 후 맨 뒤에 추가)
+                lruList.remove(cityLower);
+                lruList.addLast(cityLower);
+            } else {
+                answer += 5;  // cache miss
+                
+                // 캐시가 가득 찼으면 가장 오래된 항목(LRU의 첫 번째 항목) 제거
+                if (lruList.size() >= cacheSize) {
+                    String oldestCity = lruList.pollFirst();  // 첫 번째 항목 제거 및 반환
+                    if (oldestCity != null) {
+                        cache.remove(oldestCity);
+                    }
+                }
+                
+                // 새 도시 추가
+                if (cacheSize > 0) {
+                    cache.put(cityLower, 1);  // 값은 존재 여부만 확인하므로 아무 값이나 가능
+                    lruList.addLast(cityLower);
+                }
+            }
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 캐시
- **문제 링크**: https://school.programmers.co.kr/learn/courses/30/lessons/17680

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
해시 맵에 아이템을 두어 검색시 한번에 가져갈 수 있도록 구현하고 lruList 를 만들어서 가장 앞쪽에 옛날에 쓴 아이템을 유지하기 위해 linkedlist 로 구현하였습니다.


## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
hashmap 에서 remove 를 할때 hashCode 를 기준으로 하니 remove(Object o) 와 remove(int O) 와 충돌이 나 오류가 발생하였습니다. int key 를 기준으로 remove 는 되도록 조심해야 할 것 같습니다.

찾아 보니

// remove(int index)가 아닌 remove(Object o)를 호출하도록 명시적 캐스팅
lruList.remove((Integer)key);

이런 식으로 명시적 캐스팅을 하면 remove(Object o) 로 되어 메서드 오버로딩에 의한 충돌이 나지 않는다고 합니다.