### PR TITLE
[4월 1주차] 가장 긴 증가하는 부분수열 - 정연수

### DIFF
--- a/APR/WEEK1/가장_긴_증가하는_부분수열/정연수.java
+++ b/APR/WEEK1/가장_긴_증가하는_부분수열/정연수.java
@@ -1,0 +1,43 @@
+package day_0401;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int[] dp;
+	static int[] nums;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		st = new StringTokenizer(br.readLine());
+		int num = Integer.parseInt(st.nextToken());
+		
+		dp = new int[num];
+		nums = new int[num];
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < num; i++) {
+			nums[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		dp[0] = 1;
+		for (int i = 1; i < num; i++) {
+			int maxCnt = 0;
+			for (int j = 0; j < i; j++) {
+				if (nums[i] > nums[j])
+					maxCnt = Math.max(maxCnt, dp[j]);
+			}
+			dp[i] = maxCnt + 1;
+		}
+		
+		int answer = 0;
+		for (int i = 0; i < num; i++) {
+			answer = Math.max(answer, dp[i]);
+		}
+		System.out.println(answer);
+	}
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 가장 긴 증가하는 부분 수
- **문제 링크**: https://www.acmicpc.net/problem/11053

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
마찬가지로 간단한 1차원 dp입니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
