### PR TITLE
[4월] 친구 네트워크 - 박재환

### DIFF
--- a/APR/친구_네트워크/박재환.java
+++ b/APR/친구_네트워크/박재환.java
@@ -1,0 +1,99 @@
+package APR.친구_네트워크;
+
+import java.util.*;
+import java.io.*;
+
+public class 박재환 {
+    static BufferedReader br;
+    static StringBuilder sb;
+    public static void main(String[] args) throws IOException {
+        br = new BufferedReader(new InputStreamReader(System.in));
+        sb = new StringBuilder();
+        int TC = Integer.parseInt(br.readLine().trim());
+        for(int testCase=0; testCase<TC; testCase++) {
+            init();
+        }
+        br.close();
+        System.out.println(sb);
+    }
+
+    static StringTokenizer st;
+    static int relationCnt;		// 각 테스트에서의 관계의 수
+    static Map<String, Integer> nameMap;	// 각 사람의 이름 -> 인덱스 저장 정보
+    static int idx;							// 사람의 이름과 매핑할 인덱스
+    static void init() throws IOException {
+        idx = 0;
+        nameMap = new HashMap<>();
+        relationCnt = Integer.parseInt(br.readLine().trim());
+
+        make();
+
+        while(relationCnt-- > 0) {
+            st = new StringTokenizer(br.readLine().trim());
+
+            int nameA = convertName(st.nextToken());
+            int nameB = convertName(st.nextToken());
+
+            findNetWorking(nameA, nameB);
+        }
+    }
+
+    /*
+     * Union-Find 를 사용한다.
+     */
+    static void findNetWorking(int nodeA, int nodeB) {
+        union(nodeA, nodeB);
+
+        sb.append(sizes[find(nodeA)]).append('\n');
+    }
+
+    static int[] parents;
+    static int[] sizes;
+    static void make() {
+        parents = new int[relationCnt*2];
+        sizes = new int[relationCnt*2];
+
+        for(int idx=0; idx<relationCnt*2; idx++) {
+            parents[idx] = idx;
+            sizes[idx] = 1;		// 자기 자신만 포함
+        }
+    }
+
+    static int find(int node) {
+        if(parents[node] == node) return node;
+
+        return parents[node] = find(parents[node]);
+    }
+
+    static void union(int nodeA, int nodeB) {
+        int rootA = find(nodeA);
+        int rootB = find(nodeB);
+
+        if(rootA == rootB) return;
+
+        // 더 작은 트리를 큰 트리에 합침 -> 높이 변화 X
+        if (sizes[rootA] < sizes[rootB]) {
+            parents[rootA] = rootB;
+            sizes[rootB] += sizes[rootA];  // rootB의 집합 크기 갱신
+        } else {
+            parents[rootB] = rootA;
+            sizes[rootA] += sizes[rootB];  // rootA의 집합 크기 갱신
+        }
+    }
+
+    // Map 에 저장하여 각 이름의 인덱스 관리하기
+    static int convertName(String name) {
+        if(nameMap.containsKey(name)) return nameMap.get(name);
+
+        // 처음 들어오는 친구이름이라면, idx 값 증가
+        nameMap.put(name, idx);
+        return idx++;
+    }
+}
+
+/*
+ * 어떤 사이트의 친구 관계가 생긴 순으로 주어졌을 때, 두 사람의 친구 네트워크에 몇 명이 있는가
+ * 친구 네트워크 : 친구 관계만으로 이동할 수 있는 사이클
+ *
+ * 친구 관계가 생길 때마다, 두 사람의 친구 네트워크에 몇 명이 있는지 구하라
+ */


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 친구 네트워크
- **문제 링크**: https://www.acmicpc.net/problem/4195

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
메모리 : 56264 KB
시간 : 504 ms
## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
두 친구의 연결 사이에 몇 명이 포함되었는지 구하는 문제로 **Union-Find** 를 사용해야한다 생각하였고, 이때 Rank 관리를 통해 각 트리에 속한 원소의 개수를 기록하였습니다. 

처음에는 들어오는 name 값을 char 값으로 해싱하여 문제를 풀었지만 이럴경우 ab, ba 이  두 케이스가 같은 문자로 인식되어서 틀렸습니다. 
따라서 Map 또는 List 등을 사용하여 각 name 의 인덱스를 관리하였습니다. 저는 Map 의 contains 와 get 이 O(1) 의 시간이 걸리는 것을 이용하여 HashMap 을 사용하였습니다.  

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
해시 충돌을 피해보려고 좀 알아봤는데, 너무 복잡해서 포기했습니다...