### PR TITLE
[4월 3주차] 가장 긴 바이토닉 부분 수열 - 정한슬

### DIFF
--- a/APR/WEEK3/가장_긴_바이토닉_부분_수열/정한슬.java
+++ b/APR/WEEK3/가장_긴_바이토닉_부분_수열/정한슬.java
@@ -1,0 +1,87 @@
+import java.util.*;
+import java.io.*;
+
+/*
+ * 바이토닉 수열이란? 해당 인덱스 기준으로 왼쪽은 증가, 오른쪽은 감소하는 수열
+ * 가장 긴 바이토닉 부분 수열을 구하기 위해선
+ * 왼쪽 배열(증가 부분 수열)
+ * 오른 쪽 배열(증가 감소 수열)을 만든 다음
+ * 특정 인덱스에서 왼쪽 배열값과 오른쪽 배열값을 더한 값이 가장 긴 바이토닉 부분 수열일 것.
+ * -> 이때 left[i] + right[i] 하고 + 1을 해야 자기자신까지 포함할 수 있다.
+ * 
+ * 증가 부분 수열을 만드는 방법
+ * 1. n^2으로 dp
+ * 2. 이분 탐색으로 가장 긴 부분 수열의 길이를 저장
+ * */
+public class 정한슬 {
+	static BufferedReader br;
+	static StringTokenizer st;
+	static BufferedWriter bw;
+	
+	static int sequenceLength;
+	static int[] sequence;
+	
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		initInput();
+		br.close();
+		
+		int[] left = makeLeftArr();
+		int[] right = makeRightArr();
+		bw.write(String.valueOf(getMaxLengthBitonic(left, right)));
+		bw.flush();
+		bw.close();
+	}
+	
+	private static int[] makeRightArr() {
+		int[] right = new int[sequenceLength];
+		// 증가하는 부분 수열 찾기
+		for (int idx1 = 0; idx1 < sequenceLength; idx1++) {
+			for (int idx2 = 0; idx2 < idx1; idx2++) {
+				if (sequence[idx1] > sequence[idx2]) {
+					right[idx1] = Math.max(right[idx1], right[idx2] + 1);
+				}
+			}
+		}
+//		System.out.println("right: " + Arrays.toString(right));
+		
+		return right;
+	}
+	
+	private static int[] makeLeftArr() {
+		int[] left = new int[sequenceLength];
+		// 감소하는 수열 찾기
+		for (int idx1 = sequenceLength - 1; idx1 >= 0; idx1--) {
+			for (int idx2 = sequenceLength - 1; idx2 > idx1; idx2--) {
+				if (sequence[idx1] > sequence[idx2]) {
+					left[idx1] = Math.max(left[idx1], left[idx2] + 1);
+				}
+			}
+		}
+		
+//		System.out.println("left: " + Arrays.toString(left));
+		return left;
+	}
+	
+	private static int getMaxLengthBitonic(int[] left, int[] right) {
+		int maxLength = 0;
+		
+		for (int idx = 0; idx < sequenceLength; idx++) {
+			maxLength = Math.max(left[idx] + right[idx], maxLength);
+		}
+		
+		return maxLength + 1;
+	}
+	
+	private static void initInput() throws IOException {
+		sequenceLength = Integer.parseInt(br.readLine().trim());
+		
+		sequence = new int[sequenceLength];
+		st = new StringTokenizer(br.readLine().trim());
+		for (int idx = 0; idx < sequenceLength; idx++) {
+			sequence[idx] = Integer.parseInt(st.nextToken());
+		}
+	}
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 가장 긴 바이토닉 부분 수열
- **문제 링크**:  https://www.acmicpc.net/problem/11054

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/bd078719-a39e-4673-b3a6-10fd1d901e55)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
특정 인덱스에서 왼쪽배열(특정 인덱스를 끝으로 증가하는 수 저장), 오른쪽 배열(특정 인덱스를 시작으로 감소하는 배열)을 만들고 특정 인덱스에서 더하면 그것이 바이토닉 부분 수열의 길이가 됩니다.
자기자신은 포함이 안되므로 +1을 하여 답을 구했습니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
