### PR TITLE
[4월 3주차] 가장 긴 바이토닉 부분 수열 - 이수빈

### DIFF
--- a/APR/WEEK3/가장_긴_바이토닉_부분_수열/이수빈.java
+++ b/APR/WEEK3/가장_긴_바이토닉_부분_수열/이수빈.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int size = Integer.parseInt(br.readLine().trim());
+
+        int[] array = new int[size];
+        int[] frontDp = new int[size];
+        int[] backDp = new int[size];
+        st = new StringTokenizer(br.readLine().trim());
+        for (int idx = 0; idx < size; idx++) {
+            array[idx] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int idx = 0; idx < size; idx++) {
+            frontDp[idx] = 1;
+            for (int prevIdx = 0; prevIdx < idx; prevIdx++) {
+                if (array[idx] > array[prevIdx]) {
+                    frontDp[idx] = Math.max(frontDp[idx], frontDp[prevIdx] + 1);
+                }
+            }
+        }
+
+        for (int idx = size - 1; idx >= 0; idx--) {
+            backDp[idx] = 1;
+            for (int prevIdx = size - 1; prevIdx > idx; prevIdx--) {
+                if (array[idx] > array[prevIdx]) {
+                    backDp[idx] = Math.max(backDp[idx], backDp[prevIdx] + 1);
+                }
+            }
+        }
+
+        int result = 1;
+        for (int idx = 0; idx < size; idx++) {
+            result = Math.max(result, frontDp[idx] + backDp[idx] - 1);
+        }
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 가장 긴 바이토닉 부분 수열
- **문제 링크**: https://www.acmicpc.net/problem/11054

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
12512KB
92ms
- [ ] 풀이 진행 중 

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
LIS를 앞에서부터, 뒤에서부터 두 방향에서 구해주고
두 배열 값의 합의 최댓값을 구해줬습니다.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
