### PR TITLE
[5월 2주차] 고층 건물 - 정한슬

### DIFF
--- a/MAY/WEEK2/고층_건물/정한슬.java
+++ b/MAY/WEEK2/고층_건물/정한슬.java
@@ -1,0 +1,83 @@
+import java.util.*;
+import java.io.*;
+
+/*
+ * 가장 많은 고층 건물이 보일 때를 선택하려면?? 
+ * 건물 A와 B 사이에서 보이는 건물 수를 카운팅하는 방법
+ * 1. 기울기 = (By - Ah) / (Bx - Ax) = a 를 구한다.
+ * 2. y = a * (x - Ax) + Bx 기울기를 구한 것을 이용하여 기존 1차 방정식을 만든다.
+ * 3. 만일 카운팅 할 빌딩(A ~ B 사이 빌딩)의 높이가 1차 방정식 y값보다 높거나 같으면 그 빌딩 이후는 보이지 않게 된다.
+ * 4. idx별로 0 ~ buildingCount, 왼쪽/ 오른쪽을 각각 보이는 빌딩 수를 구하고 max 값 갱신
+ * 
+ * 이해하기 쉬운 예제
+ * idx:      0   1   2   3   4
+ * height:   1   3   1   4   2
+ * */
+public class 정한슬 {
+	static BufferedReader br;
+	static BufferedWriter bw;
+	static StringTokenizer st;
+	
+	static int buildingCount;
+	static int[] buildings;
+	static int maxBuildingCount = 0;
+	
+	public static void main(String[] args) throws IOException {
+		br = new BufferedReader(new InputStreamReader(System.in));
+		bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		
+		initInput();
+		br.close();
+		
+		checkBuildings();
+		
+		bw.write(String.valueOf(maxBuildingCount));
+		bw.flush();
+		bw.close();
+	}
+	
+	private static void checkBuildings() {
+	    for (int buildingIdx = 0; buildingIdx < buildingCount; buildingIdx++) {
+	        int count = 0;
+
+	        // 왼쪽
+	        for (int leftIdx = buildingIdx - 1; leftIdx >= 0; leftIdx--) {
+	            if (isVisible(buildingIdx, leftIdx)) count++;
+//                else break; // 바로 안끊는 이유는, 기울기가 변할 때마다 달라질 수 있기 때문
+	        }
+
+	        // 오른쪽
+	        for (int rightIdx = buildingIdx + 1; rightIdx < buildingCount; rightIdx++) {
+	            if (isVisible(buildingIdx, rightIdx)) count++;
+//                else break; 
+	        }
+
+	        maxBuildingCount = Math.max(maxBuildingCount, count);
+	    }
+	}
+
+	private static boolean isVisible(int from, int to) {
+	    int min = Math.min(from, to);
+	    int max = Math.max(from, to);
+	    double baseSlope = (double)(buildings[to] - buildings[from]) / (to - from);
+
+	    for (int mid = min + 1; mid < max; mid++) {
+	        double expectedHeight = buildings[from] + baseSlope * (mid - from);
+	        if (buildings[mid] >= expectedHeight) {
+	            return false; // 시야를 가림
+	        }
+	    }
+
+	    return true; // 모두 통과함 = 보임
+	}
+	
+	private static void initInput() throws IOException {
+		buildingCount = Integer.parseInt(br.readLine().trim());
+		
+		buildings = new int[buildingCount];
+		st = new StringTokenizer(br.readLine().trim());
+		for (int buildingIdx = 0; buildingIdx < buildingCount; buildingIdx++) {
+			buildings[buildingIdx] = Integer.parseInt(st.nextToken());
+		}
+	}
+}


### PR DESCRIPTION
## 📝 문제 정보
[//]: # (PR 올리는 문제 이름과 문제 링크를 작성해주세요.)
- **문제 이름**: 고층 건물
- **문제 링크**: https://www.acmicpc.net/problem/1027

## ✅  풀이 진행 상태
[//]: # (풀이 완료 후에는 채점된 실행시간과 메모리를 공유해주세요!)
- [x] 풀이 완료
- [ ] 풀이 진행 중 
![image](https://github.com/user-attachments/assets/3ddde22a-422b-496e-b549-697f7890c73b)

## 💡  내 풀이 간단 설명
<!-- 자유 양식으로 간단히 풀이 과정을 공유해주세요. 아래는 기본 예시입니다.
- 큰 동전부터 차례대로 나누어 풀이 (그리디 알고리즘 적용)
- DP 접근법도 고려했지만, 최적해를 보장할 수 있다고 판단하여 그리디로 해결함
-->
* 건물 A와 B 사이에서 보이는 건물 수를 카운팅하는 방법
1. 기울기 = (By - Ah) / (Bx - Ax) = a 를 구한다.
2. y = a * (x - Ax) + Bx 기울기를 구한 것을 이용하여 기존 1차 방정식을 만든다.
3. 만일 카운팅 할 빌딩(A ~ B 사이 빌딩)의 높이가 1차 방정식 y값보다 높거나 같으면 그 빌딩 이후는 보이지 않게 된다.
4. idx별로 0 ~ buildingCount, 왼쪽/ 오른쪽을 각각 보이는 빌딩 수를 구하고 max 값 갱신

위의 로직으로 풀었습니당. 뭔가 문제 보자마자 기울기, 1차 방정식으로 풀고싶어서 이 문제 먼저 풀었어욤

그리고 왜 다시 보일 때 count++만으로도 가능한지 이해를 못했는데, 
 * idx:      0   1   2   3   4
 * height:   1   3   1   4   2
이때 예제를 보고 이해했어요.

## 💬 자유 의견 
<!-- 자유롭게 의견을 남겨도 좋고 빈칸으로 진행해도 좋아요! 
아래는 예시입니다.
- 더 좋은 변수명 추천 가능할까요?
- 시간 복잡도를 고려했을 때 개선할 부분이 있을까요?
- 이번 문제같은 경우에는 너무 어렵던데 이런 문제는 2일에 걸쳐 풀고 싶어요.
-->
수학적으로 접근해놓고 비교할 1차 방정식을 단순하게 y = a * x로 생각하고 기울기도 int로 하고.. 수학적인듯 수학적이지 않은 나의 brain~